### PR TITLE
chore: fix typos

### DIFF
--- a/04-analytics-engineering/SQL_refresher.md
+++ b/04-analytics-engineering/SQL_refresher.md
@@ -3,7 +3,7 @@
 ### Table of contents
 
 
-- [Window Funtions](#window-funtions)
+- [Window Functions](#window-funtions)
     - [Row Number](#row-number)
     - [Rank and Dense Rank](#rank-and-dense-rank)    
     - [Lag and Lead](#lag-and-lead)   
@@ -13,7 +13,7 @@
 
 
 
-## Window Funtions    
+## Window Functions    
 
 A window function performs a calculation across a set of table rows that are related to the current row within a specific "window" or subset of data. This is comparable to the type of calculation that can be done with an aggregate function  (such as SUM(), AVG(), COUNT(), etc.).
 
@@ -217,7 +217,7 @@ PERCENTILE_CONT(value_expression, percentile ) OVER (PARTITION BY partition_expr
 
 **Example:**
 
-Lets calculate the 90th percentile of total_amount for each unique pickup location (PULocationID)
+Let's calculate the 90th percentile of total_amount for each unique pickup location (PULocationID)
 
 ```sql
 


### PR DESCRIPTION
Here are the typos found in the `SQL_refresher.md`:

1. **"Window Funtions"** - Should be **"Window Functions"** (multiple instances in the table of contents and headings).

2. **"Lets calculate"** - Should be **"Let's calculate"** (missing apostrophe in "Let's").

## Summary by Sourcery

Fix typos in SQL refresher documentation

Chores:
- Corrected spelling of 'Window Functions' throughout the document
- Added missing apostrophe in 'Let's calculate'